### PR TITLE
proto: add extra 'go_srcs' option

### DIFF
--- a/proto/core.rst
+++ b/proto/core.rst
@@ -242,6 +242,13 @@ Attributes
 | protoc plugins used to generate Go code. See `Predefined plugins`_ for                       |
 | some options.                                                                                |
 +---------------------+----------------------+-------------------------------------------------+
+| :param:`go_srcs`    | :type:`label_list`   | :value:`[]` |
++---------------------+----------------------+-------------------------------------------------+
+| List of Go additional source files that are compiled with the generated sources.             |
+| This can be useful if the generated souces depend on these sources, but as an alternative to |
+| `embed` which does not require defining a separate go_library for for these sources, as they |
+| may be unable to build on their own i.e. if they reference symbols in the generated sources. |
++---------------------+----------------------+-------------------------------------------------+
 
 Example: Basic proto
 ^^^^^^^^^^^^^^^^^^^^

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -31,6 +31,13 @@ load(
     "@rules_proto//proto:defs.bzl",
     "ProtoInfo",
 )
+load(
+    "//go/private:common.bzl",
+    "asm_exts",
+    "cgo_exts",
+    "go_exts",
+    "as_iterable",
+)
 
 GoProtoImports = provider()
 
@@ -98,7 +105,7 @@ def _go_proto_library_impl(ctx):
             fail("Either proto or protos (non-empty) argument must be specified")
         proto_deps = ctx.attr.protos
 
-    go_srcs = []
+    go_srcs = [f for t in ctx.attr.go_srcs for f in as_iterable(t.files)]
     valid_archive = False
 
     for c in compilers:
@@ -146,6 +153,7 @@ go_proto_library = rule(
             providers = [GoLibrary],
             aspects = [_go_proto_aspect],
         ),
+        "go_srcs": attr.label_list(allow_files = go_exts + asm_exts + cgo_exts, default = []),
         "importpath": attr.string(),
         "importmap": attr.string(),
         "importpath_aliases": attr.string_list(),  # experimental, undocumented

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -55,6 +55,23 @@ go_test(
     ],
 )
 
+# extra_sources_test
+go_proto_library(
+    name = "extra_go_proto",
+    go_srcs = ["extra.go"],
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/foo",
+    proto = ":foo_proto",
+)
+
+go_test(
+    name = "extra_sources_test",
+    srcs = ["embed_test.go"],
+    deps = [
+        ":extra_go_proto",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)
+
 # transitive_test
 go_proto_library(
     name = "transitive_go_proto",


### PR DESCRIPTION
This adds a 'go_srcs' attribute to the go_proto_library rule which
can be used to specify additional go source files that should be included
in the sources of the derived go_library. These can be required when using
non-proto-defined types in the generated proto, e.g. via 'casttype' which
are defined in files that also then reference proto-defined types,
creating a circular dependency between those files, which are intended
to be built as a single package. Thus those extra sources need to be
included in the go_proto_library's generated go_library.
