### PR TITLE
compilepkg: rework fix for stored file path truncation

### DIFF
--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -204,19 +204,14 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSr
 
 	// Copy regular Go source files into the work directory so that we can
 	// use -trimpath=workDir.
-	subDir := filepath.Join(workDir, packagePath)
-	err = os.MkdirAll(subDir, 0755)
-	if err != nil {
-		return "", nil, nil, err
-	}
-	goBases, err := gatherSrcs(subDir, goSrcs)
+	goBases, err := gatherSrcs(workDir, goSrcs)
 	if err != nil {
 		return "", nil, nil, err
 	}
 
 	allGoSrcs = make([]string, len(goSrcs)+len(genGoSrcs))
 	for i := range goSrcs {
-		allGoSrcs[i] = filepath.Join(subDir, goBases[i])
+		allGoSrcs[i] = filepath.Join(workDir, goBases[i])
 	}
 	copy(allGoSrcs[len(goSrcs):], genGoSrcs)
 	return workDir, allGoSrcs, cObjs, nil

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -284,16 +284,7 @@ func compileArchive(
 				return err
 			}
 		}
-		subDir := filepath.Join(workDir, packagePath)
-		err := os.MkdirAll(subDir, 0755)
-		if err != nil {
-			return err
-		}
-		goBases, err := gatherSrcs(subDir, goSrcs)
-		for i, base := range goBases {
-			goSrcs[i] = filepath.Join(subDir, base)
-		}
-		gcFlags = append(gcFlags, "-trimpath="+workDir)
+		gcFlags = append(gcFlags, "-trimpath=.")
 	}
 
 	// Check that the filtered sources don't import anything outside of


### PR DESCRIPTION
These commits rework the fix for https://github.com/cockroachdb/cockroach/issues/64379. We no longer have to copy the files into a temporary directory.

This fixes an issue with file paths in errors; the previous fix caused those to be the full paths, like
```
/tmp/rules_go_work-3549239678/github.com/cockroachdb/cockroach/pkg/sql/scan.go:91:20: undefined: descpbx
```
With this change we are back to the way things were before that fix, i.e.
```
pkg/sql/scan.go:91:20: undefined: descpbx
```

#### Revert "Stage Go sources in a directory named after the package."

This reverts commit 18a0557abfe2e1029fa12e35a46e846eb2564292.

#### compilepkg: fix stored file path truncation

This fixes the issue described in cockroachdb/cockroach#64379 where
the internal paths of the files don't include the
`github.com/cockroachdb/cockroach` prefix.

We fix this by using the rewrite syntax of `-trimpath`, e.g.
`-trimpath=/sandbox/execroot=>github.com/cockroachdb/cockroach`.

Figuring out the replacement part is not trivial. We use the package
path and strip out the relative path of the source file directory.
