### PR TITLE
sdk: symlink everything under lib/ when using local SDK

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -219,7 +219,7 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
         )
 
 def _local_sdk(ctx, path):
-    for entry in ["src", "pkg", "bin"]:
+    for entry in ["src", "pkg", "bin", "lib"]:
         ctx.symlink(path + "/" + entry, entry)
 
 def _sdk_build_file(ctx, platform):


### PR DESCRIPTION
We rely on the packaged zoneinfo zip in CRDB, found under
lib/time/zoneinfo.zip. When using the remote SDK, we untar the entire
thing into our sandbox. When pointing to a local SDK however, we ignored
everything under lib, so failed to build.

We'll need this diff in order to build CRDB with modified go
installations, or at least iterating on it locally.

+cc https://github.com/cockroachdb/cockroach/issues/56178