### PR TITLE
record results of `unused` lint in `.x` archives next to `nogo` output

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -39,7 +39,7 @@ load(
     "emit_compilepkg",
 )
 
-def emit_archive(go, source = None, _recompile_suffix = ""):
+def emit_archive(go, source = None, _recompile_suffix = "", extra_archive_datas = []):
     """See go/toolchains.rst#archive for full documentation."""
 
     if source == None:
@@ -185,6 +185,7 @@ def emit_archive(go, source = None, _recompile_suffix = ""):
         # Information needed by dependents
         file = out_lib,
         export_file = out_export,
+        extra_archive_datas = tuple(extra_archive_datas),
         data_files = as_tuple(data_files),
         _cgo_deps = as_tuple(cgo_deps),
     )

--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -38,7 +38,7 @@ def emit_binary(
     if name == "" and executable == None:
         fail("either name or executable must be set")
 
-    archive = go.archive(go, source)
+    archive = go.archive(go, source, extra_archive_datas = test_archives)
     if not executable:
         extension = go.exe_extension
         if go.mode.link == LINKMODE_C_SHARED:

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -77,6 +77,7 @@ go_source(
     tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
+        "@co_honnef_go_tools//unused",
         "@org_golang_x_tools//go/analysis",
         "@org_golang_x_tools//go/analysis/internal/facts:go_default_library",
         "@org_golang_x_tools//go/gcexportdata",

--- a/go/tools/builders/compile.go
+++ b/go/tools/builders/compile.go
@@ -165,6 +165,7 @@ func compile(args []string) error {
 	var nogoOutput bytes.Buffer
 	nogoStatus := nogoNotRun
 	outFact := filepath.Join(xTempDir, nogoFact)
+	outUnused := filepath.Join(xTempDir, "unused.out")
 	if *nogo != "" {
 		var nogoargs []string
 		nogoargs = append(nogoargs, "-p", *packagePath)
@@ -173,6 +174,7 @@ func compile(args []string) error {
 			nogoargs = append(nogoargs, "-fact", fmt.Sprintf("%s=%s", arc.importPath, arc.file))
 		}
 		nogoargs = append(nogoargs, "-x", outFact)
+		nogoargs = append(nogoargs, "-u", outUnused)
 		nogoargs = append(nogoargs, filenames...)
 		nogoCmd := exec.Command(*nogo, nogoargs...)
 		nogoCmd.Stdout, nogoCmd.Stderr = &nogoOutput, &nogoOutput
@@ -215,7 +217,7 @@ func compile(args []string) error {
 	}
 	pkgDefPath := filepath.Join(xTempDir, pkgDef)
 	if nogoStatus == nogoSucceeded {
-		return appendFiles(goenv, *outExport, []string{pkgDefPath, outFact})
+		return appendFiles(goenv, *outExport, []string{pkgDefPath, outFact, outUnused})
 	}
 	return appendFiles(goenv, *outExport, []string{pkgDefPath})
 }

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -395,11 +395,12 @@ func compileArchive(
 	// Run nogo concurrently.
 	var nogoChan chan error
 	outFactsPath := filepath.Join(workDir, nogoFact)
+	outUnusedPath := filepath.Join(workDir, "unused.out")
 	if nogoPath != "" {
 		ctx, cancel := context.WithCancel(context.Background())
 		nogoChan = make(chan error)
 		go func() {
-			nogoChan <- runNogo(ctx, workDir, nogoPath, goSrcs, deps, packagePath, importcfgPath, outFactsPath)
+			nogoChan <- runNogo(ctx, workDir, nogoPath, goSrcs, deps, packagePath, importcfgPath, outFactsPath, outUnusedPath)
 		}()
 		defer func() {
 			if nogoChan != nil {
@@ -488,7 +489,7 @@ func compileArchive(
 	}
 	pkgDefPath := filepath.Join(workDir, pkgDef)
 	if nogoStatus == nogoSucceeded {
-		return appendFiles(goenv, outXPath, []string{pkgDefPath, outFactsPath})
+		return appendFiles(goenv, outXPath, []string{pkgDefPath, outFactsPath, outUnusedPath})
 	}
 	return appendFiles(goenv, outXPath, []string{pkgDefPath})
 }
@@ -513,7 +514,7 @@ func compileGo(goenv *env, srcs []string, packagePath, importcfgPath, embedcfgPa
 	return goenv.runCommandAndReplacePaths(args, paths)
 }
 
-func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string, deps []archive, packagePath, importcfgPath, outFactsPath string) error {
+func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string, deps []archive, packagePath, importcfgPath, outFactsPath, outUnusedPath string) error {
 	args := []string{nogoPath}
 	args = append(args, "-p", packagePath)
 	args = append(args, "-importcfg", importcfgPath)
@@ -521,6 +522,7 @@ func runNogo(ctx context.Context, workDir string, nogoPath string, srcs []string
 		args = append(args, "-fact", fmt.Sprintf("%s=%s", dep.importPath, dep.file))
 	}
 	args = append(args, "-x", outFactsPath)
+	args = append(args, "-u", outUnusedPath)
 	args = append(args, srcs...)
 
 	paramsFile := filepath.Join(workDir, "nogo.param")

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -22,6 +22,7 @@ package main
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -41,6 +42,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/internal/facts"
 	"golang.org/x/tools/go/gcexportdata"
+	"honnef.co/go/tools/unused"
 )
 
 func init() {
@@ -50,6 +52,11 @@ func init() {
 }
 
 var typesSizes = types.SizesFor("gc", os.Getenv("GOARCH"))
+
+type UnusedResult struct {
+	Unused map[string]*[]string
+	Used   map[string]*[]string
+}
 
 func main() {
 	log.SetFlags(0) // no timestamp
@@ -73,6 +80,7 @@ func run(args []string) error {
 	importcfg := flags.String("importcfg", "", "The import configuration file")
 	packagePath := flags.String("p", "", "The package path (importmap) of the package being compiled")
 	xPath := flags.String("x", "", "The archive file where serialized facts should be written")
+	unusedPath := flags.String("u", "", "The archive file where unused outupt data should be written")
 	flags.Parse(args)
 	srcs := flags.Args()
 
@@ -81,7 +89,7 @@ func run(args []string) error {
 		return fmt.Errorf("error parsing importcfg: %v", err)
 	}
 
-	diagnostics, facts, err := checkPackage(analyzers, *packagePath, packageFile, importMap, factMap, srcs)
+	diagnostics, facts, actions, err := checkPackage(analyzers, *packagePath, packageFile, importMap, factMap, srcs)
 	if err != nil {
 		return fmt.Errorf("error running analyzers: %v", err)
 	}
@@ -93,8 +101,91 @@ func run(args []string) error {
 			return fmt.Errorf("error writing facts: %v", err)
 		}
 	}
+	if *unusedPath != "" {
+		out := UnusedResult{
+			Unused: make(map[string]*[]string),
+			Used:   make(map[string]*[]string),
+		}
+		for _, act := range actions {
+			if act.a.Name == "U1000" {
+				result, ok := act.result.(unused.Result)
+				if !ok {
+					return fmt.Errorf("unexpected result type for unused analyzer")
+				}
+				for _, unusedObj := range result.Unused {
+					if !careAboutObjectUsed(unusedObj, act.pkg.fset) {
+						continue
+					}
+					registerObjectUsed(unusedObj, out.Unused)
+				}
+				for _, usedObj := range result.Used {
+					if !careAboutObjectUsed(usedObj, act.pkg.fset) {
+						continue
+					}
+					registerObjectUsed(usedObj, out.Used)
+				}
+				for _, lst := range out.Unused {
+					sortAndDedup(lst)
+				}
+				for _, lst := range out.Used {
+					sortAndDedup(lst)
+				}
+				break
+			}
+		}
+		encoded, err := json.Marshal(out)
+		if err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(abs(*unusedPath), encoded, 0666); err != nil {
+			return fmt.Errorf("error writing unused out: %v", err)
+		}
+	}
 
 	return nil
+}
+
+func careAboutObjectUsed(obj types.Object, fset *token.FileSet) bool {
+	if obj.Exported() || !strings.HasPrefix(obj.Pkg().Path(), "github.com/cockroachdb/cockroach/") {
+		// Exported functions are never reported by the unused linter,
+		// and we won't bother with stuff that doesn't come from the
+		// cockroach repo itself.
+		return false
+	}
+	filename := fset.Position(obj.Pos()).Filename
+	if strings.HasSuffix(filename, ".eg.go") || strings.HasSuffix(filename, ".pb.go") || strings.HasSuffix(filename, ".pb.gw.go") || strings.HasSuffix(filename, "_generated.go") {
+		return false
+	}
+	name := obj.Name()
+	if name == "_" || strings.HasPrefix(name, "_Cgo") || strings.HasPrefix(name, "_Ctype") || strings.HasPrefix(name, "_cgo") || strings.HasPrefix(name, "_Cfunc") || strings.HasPrefix(name, "__cgofn_") {
+		return false
+	}
+	return true
+}
+
+func registerObjectUsed(obj types.Object, reg map[string]*[]string) {
+	pkgPath := obj.Pkg().Path()
+	lst, ok := reg[pkgPath]
+	if ok {
+		*lst = append(*lst, obj.Name())
+	} else {
+		reg[pkgPath] = &[]string{obj.Name()}
+	}
+}
+
+func sortAndDedup(lst *[]string) {
+	sort.Strings(*lst)
+	var dst int
+	var prev string
+	for _, str := range *lst {
+		if prev == str {
+			continue
+		}
+		(*lst)[dst] = str
+		prev = str
+		dst += 1
+	}
+	*lst = (*lst)[0:dst]
 }
 
 // Adapted from go/src/cmd/compile/internal/gc/main.go. Keep in sync.
@@ -145,7 +236,7 @@ func readImportCfg(file string) (packageFile map[string]string, importMap map[st
 // It returns an empty string if no source code diagnostics need to be printed.
 //
 // This implementation was adapted from that of golang.org/x/tools/go/checker/internal/checker.
-func checkPackage(analyzers []*analysis.Analyzer, packagePath string, packageFile, importMap map[string]string, factMap map[string]string, filenames []string) (string, []byte, error) {
+func checkPackage(analyzers []*analysis.Analyzer, packagePath string, packageFile, importMap map[string]string, factMap map[string]string, filenames []string) (string, []byte, map[*analysis.Analyzer]*action, error) {
 	// Register fact types and establish dependencies between analyzers.
 	actions := make(map[*analysis.Analyzer]*action)
 	var visit func(a *analysis.Analyzer) *action
@@ -175,14 +266,14 @@ func checkPackage(analyzers []*analysis.Analyzer, packagePath string, packageFil
 		if cfg, ok := configs[a.Name]; ok {
 			for flagKey, flagVal := range cfg.analyzerFlags {
 				if strings.HasPrefix(flagKey, "-") {
-					return "", nil, fmt.Errorf(
+					return "", nil, nil, fmt.Errorf(
 						"%s: flag should not begin with '-': %s", a.Name, flagKey)
 				}
 				if flag := a.Flags.Lookup(flagKey); flag == nil {
-					return "", nil, fmt.Errorf("%s: unrecognized flag: %s", a.Name, flagKey)
+					return "", nil, nil, fmt.Errorf("%s: unrecognized flag: %s", a.Name, flagKey)
 				}
 				if err := a.Flags.Set(flagKey, flagVal); err != nil {
-					return "", nil, fmt.Errorf(
+					return "", nil, nil, fmt.Errorf(
 						"%s: invalid value for flag: %s=%s: %w", a.Name, flagKey, flagVal, err)
 				}
 			}
@@ -194,7 +285,7 @@ func checkPackage(analyzers []*analysis.Analyzer, packagePath string, packageFil
 	imp := newImporter(importMap, packageFile, factMap)
 	pkg, err := load(packagePath, imp, filenames)
 	if err != nil {
-		return "", nil, fmt.Errorf("error loading package: %v", err)
+		return "", nil, nil, fmt.Errorf("error loading package: %v", err)
 	}
 	for _, act := range actions {
 		act.pkg = pkg
@@ -206,7 +297,7 @@ func checkPackage(analyzers []*analysis.Analyzer, packagePath string, packageFil
 	// Process diagnostics and encode facts for importers of this package.
 	diagnostics := checkAnalysisResults(roots, pkg)
 	facts := pkg.facts.Encode()
-	return diagnostics, facts, nil
+	return diagnostics, facts, actions, nil
 }
 
 // An action represents one unit of analysis work: the application of


### PR DESCRIPTION
We need a way to track which objects/types are used and unused as we
compile stuff. The `.x` archives contain `nogo` information on a per-
package basis; next to the `nogo.out` file in each archive we also add
a `unused.out` file that contains a JSON description of the used and
unused objects for that package.

1. Update `go/tools/builders/nogo_main.go` with a new `-u` argument. If
   provided, `nogo` will check the results of the `unused` lint and dump
   a slightly munged version of the output to the file. We exclude
   from these files cgo-related stuff and anything that doesn't come
   from `cockroachdb/cockroch`.
2. Update `compile.go` and `compilepkg.go` to pass `-u` and to include
   this in the `.x` archive.
3. Update `archive.bzl` and `binary.bzl` to capture the location of
   re-compiled `internal` archives for tests in the `GoArchiveData`.
   We'll traverse this to enumerate all the `.x` archives for test
   targets back in `cockroach`.

