### PR TITLE
use `Pos` information for tracking unused values rather than just names

### DIFF
--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -165,11 +165,12 @@ func careAboutObjectUsed(obj types.Object, fset *token.FileSet) bool {
 
 func registerObjectUsed(obj types.Object, reg map[string]*[]string) {
 	pkgPath := obj.Pkg().Path()
+	id := fmt.Sprintf("%s:%d", obj.Name(), obj.Pos())
 	lst, ok := reg[pkgPath]
 	if ok {
-		*lst = append(*lst, obj.Name())
+		*lst = append(*lst, id)
 	} else {
-		reg[pkgPath] = &[]string{obj.Name()}
+		reg[pkgPath] = &[]string{id}
 	}
 }
 


### PR DESCRIPTION
This is similar to the key that's used by `staticcheck` itself (they use the filename/line number rather than just the Pos number: https://github.com/dominikh/go-tools/blob/555b2d3292b4793777c72aca3757a60e1b084ab1/lintcmd/lint.go#L483)