### PR TITLE
Whatever the reported `TEST_TIMEOUT` is, timeout 3 seconds before

### DIFF
--- a/go/tools/bzltestutil/wrap.go
+++ b/go/tools/bzltestutil/wrap.go
@@ -122,6 +122,18 @@ func Wrap(pkg string) error {
 	if !filepath.IsAbs(exePath) && strings.ContainsRune(exePath, filepath.Separator) && chdir.TestExecDir != "" {
 		exePath = filepath.Join(chdir.TestExecDir, exePath)
 	}
+	secsString, ok := os.LookupEnv("TEST_TIMEOUT")
+	if ok {
+		timeoutSecs, err := strconv.Atoi(secsString)
+		if err != nil {
+			return fmt.Errorf("could not parse TEST_TIMEOUT string %s: got error %w", secsString, err)
+		}
+		mungedTimeoutSecs := timeoutSecs - 3
+		if mungedTimeoutSecs <= 0 {
+			mungedTimeoutSecs = timeoutSecs
+		}
+		args = append([]string{"-test.timeout", fmt.Sprintf("%ds", mungedTimeoutSecs)}, args...)
+	}
 	cmd := exec.Command(exePath, args...)
 	cmd.Env = append(os.Environ(), "GO_TEST_WRAP=0")
 	cmd.Stderr = io.MultiWriter(os.Stderr, streamMerger.ErrW)


### PR DESCRIPTION
This allows us to see stacktraces from the binary before being forced to exit.