### PR TITLE
fix: multi /pkg/<module> problem

### DIFF
--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -169,8 +169,8 @@ func compileArchive(
 	packageListPath string,
 	outPath string,
 	outXPath string,
-	cgoExportHPath string) error {
-
+	cgoExportHPath string,
+) error {
 	workDir, cleanup, err := goenv.workDir()
 	if err != nil {
 		return err
@@ -293,7 +293,14 @@ func compileArchive(
 		// path. We use -trimpath to replace the root path with the correct prefix
 		// of the package path.
 		root := abs(".")
-		relSrcPath, err := filepath.Rel(root, srcs.goSrcs[0].filename)
+		srcFullPath := srcs.goSrcs[0].filename
+		for _, goSrc := range srcs.goSrcs {
+			if !strings.HasSuffix(goSrc.filename, ".pb.go") {
+				srcFullPath = goSrc.filename
+				break
+			}
+		}
+		relSrcPath, err := filepath.Rel(root, srcFullPath)
 		if err != nil {
 			return err
 		}
@@ -407,8 +414,8 @@ func compileArchive(
 	// Compile the .s files.
 	if len(srcs.sSrcs) > 0 {
 		includeSet := map[string]struct{}{
-			filepath.Join(os.Getenv("GOROOT"), "pkg", "include"): struct{}{},
-			workDir: struct{}{},
+			filepath.Join(os.Getenv("GOROOT"), "pkg", "include"): {},
+			workDir: {},
 		}
 		for _, hdr := range srcs.hSrcs {
 			includeSet[filepath.Dir(hdr.filename)] = struct{}{}


### PR DESCRIPTION
When I try to debug cockroach with VSCode, I found some bugs when I try to set breakpoints.
VSCode tells me that some files cannot be found in dlv sources, even if I use this to substitute the path to package path:
``` json
  {
    "from": "${workspaceFolder}",
    "to": "github.com/cockroachdb/cockroach"
  }, 
```
One of the cases is `/pkg/gossip/gossip.go`
When using `dlv` as follows:
```shell
dlv exec ../_bazel/bin/pkg/cmd/cockroach/cockroach_/cockroach -- start --insecure --store=node1 --listen-addr=localhost:26257 --http-addr=localhost:8080 --join=localhost:26257,localhost:26258,localhost:26259
```
and then use `sources` command to list all sources. You can find its path like this:

`github.com/cockroachdb/cockroach/pkg/gossip/pkg/gossip/gossip.go`
The relpath `pkg/gossip` has been appended twice.

This problem is associated with one issue in cockroach:
https://github.com/cockroachdb/cockroach/issues/64379
You modified complilepkg.go as follows:
```go
// We want the source files to show up (e.g. in stack traces) with the package
// path. We use -trimpath to replace the root path with the correct prefix
// of the package path.
root := abs(".")
relSrcPath, err := filepath.Rel(root, srcs.goSrcs[0].filename)
if err != nil {
  return err
}
rootPkgPath := filepath.Clean(strings.TrimSuffix(packagePath, filepath.Dir(relSrcPath)))
gcFlags = append(gcFlags, fmt.Sprintf("-trimpath=%s=>%s", root, rootPkgPath))
```
But when you debug bazel, you can get the command passed bazel looks like this:
```
bazel-out/k8-opt-exec-ST-13d3ddad9198/bin/external/go_sdk/builder_reset/builder compilepkg 
-sdk external/go_sdk -installsuffix linux_amd64 -tags bazel,gss,bazel,gss 
-src bazel-out/k8-dbg/bin/foo/foo_go_proto_/example.com/foo/foo.pb.go 
-src foo/foo.go -embedroot bazel-out/k8-dbg/bin -embedroot '' 
-embedlookupdir foo/foo_go_proto_/example.com/foo -embedlookupdir foo 
(serveral arcs)
-importpath heyhey -p example.com/foo -package_list bazel-out/k8-opt-exec-ST-13d3ddad9198/bin/external/go_sdk/packages.txt -o bazel-out/k8-dbg/bin/foo/foo.a -x bazel-out/k8-dbg/bin/foo/foo.x -gcflags '-N -l' -asmflags '')
```
The first src is the protobuf file and therefore `srcs.goSrcs[0].filename` is `bazel-out/k8-dbg/bin/foo/foo_go_proto_/example.com/foo/foo.pb.go`, but we are expecting the source file which is not generated.

so I modify this part as follows:
```go
srcFullPath := srcs.goSrcs[0].filename
for _, goSrc := range srcs.goSrcs {
  if !strings.HasSuffix(goSrc.filename, ".pb.go") {
    srcFullPath = goSrc.filename
    break
  }
}
relSrcPath, err := filepath.Rel(root, srcFullPath)
```
Once srcs has source code which is not generated, we use its path.
Then problem is fixed, and we get its path in `dlv` as follows:
`github.com/cockroachdb/cockroach/pkg/gossip/gossip.go`
