### PR TITLE
fix: tests respect --strip like binaries (#4103) (#4164)

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -134,7 +134,7 @@ def _go_test_impl(ctx):
     )
 
     test_gc_linkopts = gc_linkopts(ctx)
-    if not go.mode.debug:
+    if not go.mode.debug and go.mode.strip:
         # Disable symbol table and DWARF generation for test binaries.
         test_gc_linkopts.extend(["-s", "-w"])
 


### PR DESCRIPTION
Backport https://github.com/bazel-contrib/rules_go/pull/4164
