### PR TITLE
go_binary: fix `pgoprofile` default

### DIFF
--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -400,14 +400,13 @@ _go_binary_kwargs = {
             </ul>
             """,
         ),
-        "pgoprofile": attr.label(
-            allow_files = True,
+        "pgoprofile": attr.string(
             doc = """Provides a pprof file to be used for profile guided optimization when compiling go targets.
             A pprof file can also be provided via `--@io_bazel_rules_go//go/config:pgoprofile=<label of a pprof file>`.
             Profile guided optimization is only supported on go 1.20+.
             See https://go.dev/doc/pgo for more information.
             """,
-            default = "//go/config:empty",
+            default = "auto",
         ),
         "_go_context_data": attr.label(default = "//:go_context_data", cfg = go_transition),
         "_allowlist_function_transition": attr.label(


### PR DESCRIPTION
This fixes bazel-contrib/rules_go#4226.